### PR TITLE
Load grep for using grep-mode-tool-bar-map and grep-hit-face

### DIFF
--- a/sift.el
+++ b/sift.el
@@ -38,7 +38,7 @@
 ;;; Code:
 
 (require 'compile)
-
+(require 'grep)
 
 ;; Customization
 ;; --------------------------


### PR DESCRIPTION
Error is occurred if grep.el is not loaded as below.

```
let: Symbol's value as variable is void: grep-mode-tool-bar-map
```
