### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -89,5 +89,4 @@
          ;; (error
          ;;  (message (ansi-red "[sift] Error during unit tests : %s" ex))))))
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
The verified that the tests still succeed after this change.*

The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Also see https://github.com/rejeep/ert-runner.el/issues/38.

