### PR TITLE
Do not require test-helper

### DIFF
--- a/test/sift-version-test.el
+++ b/test/sift-version-test.el
@@ -22,8 +22,6 @@
 ;;; Code:
 
 
-(require 'test-helper)
-
 (ert-deftest phpunit-mode-library-version ()
   :tags '(version)
   :expected-result (if (executable-find "cask") :passed :failed)


### PR DESCRIPTION
Do not require `test-helper`.  That feature
isn't (and should not be) provided.

Also see https://github.com/rejeep/ert-runner.el/issues/38.