### PR TITLE
sift-regexp: prevent search terms being interpreted as flags

### DIFF
--- a/sift.el
+++ b/sift.el
@@ -167,7 +167,7 @@ This function is called from `compilation-filter-hook'."
                 (append (list sift-executable)
                         sift-arguments
                         args
-                        '("--color" "-n" "--stats")
+                        '("--color" "-n" "--stats" "--")
                         (list (shell-quote-argument regexp) ".")) " ")
      'sift-search-mode)))
 


### PR DESCRIPTION
Add -- to the end of the command-line arguments so that e.g. M-x sift-regexp
RET -10 RET does not cause an error.